### PR TITLE
Fix restart speed issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,9 +212,12 @@
             bombThreshold: 500,
             nextBombScore: 500,
             bombAvailable: false,
-            
+
             // High scores
-            highScores: []
+            highScores: [],
+
+            // Animation frame id
+            loopId: null
         };
         
         // Paddle class
@@ -547,6 +550,11 @@
         }
 
         function startGame() {
+            if (game.loopId !== null) {
+                cancelAnimationFrame(game.loopId);
+                game.loopId = null;
+            }
+
             game.running = true;
             game.paused = false;
             game.score = 0;
@@ -852,7 +860,7 @@
             if (!game.running) return;
 
             if (game.paused) {
-                requestAnimationFrame(gameLoop);
+                game.loopId = requestAnimationFrame(gameLoop);
                 return;
             }
 
@@ -876,8 +884,8 @@
             game.particles.forEach(particle => particle.draw());
             
             updateUI();
-            
-            requestAnimationFrame(gameLoop);
+
+            game.loopId = requestAnimationFrame(gameLoop);
         }
         
         // Initialize when page loads


### PR DESCRIPTION
## Summary
- ensure old animation frame is cancelled before restarting
- store animation loop ID on the `game` object
- update game loop to track frame ID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686119eed87c832cb69f96dbc9aaa752