### PR TITLE
Fix bomb score and freeze ball on level transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,10 @@
             highScores: [],
 
             // Animation frame id
-            loopId: null
+            loopId: null,
+
+            // Flag for level transitions
+            transitioning: false
         };
         
         // Paddle class
@@ -340,7 +343,11 @@
                         
                         // Check for level completion
                         if (game.aliens.length === 0 && game.reinforcements === 0) {
-                            nextLevel();
+                            freezeBall();
+                            game.transitioning = true;
+                            setTimeout(() => {
+                                nextLevel();
+                            }, 1000);
                         }
                         
                         break;
@@ -574,7 +581,9 @@
             startGame();
         }
         
-        function resetLevel() {
+       function resetLevel() {
+            game.transitioning = false;
+
             // Clear existing game objects
             game.aliens = [];
             game.bombs = [];
@@ -704,9 +713,16 @@
                 }
             }
         }
+
+        function freezeBall() {
+            if (game.ball) {
+                game.ball.velX = 0;
+                game.ball.velY = 0;
+            }
+        }
         
         function checkBombSpawn() {
-            if (game.score >= game.nextBombScore && game.bombs.length === 0) {
+            if (!game.transitioning && game.score >= game.nextBombScore && game.bombs.length === 0) {
                 let x = Math.random() * (game.width - 200) + 100;
                 let y = Math.random() * 200 + 100;
                 game.bombs.push(new Bomb(x, y));
@@ -723,9 +739,13 @@
         function collectBomb(index) {
             // Remove bomb
             game.bombs.splice(index, 1);
-            
-            // Destroy all aliens and award bonus points
-            let bonusPoints = game.aliens.length * 50;
+
+            // Freeze ball during level transition
+            freezeBall();
+            game.transitioning = true;
+
+            // Destroy all aliens and award fixed bonus points
+            let bonusPoints = game.level * 100;
             game.score += bonusPoints;
             
             // Create explosion particles


### PR DESCRIPTION
## Summary
- stop awarding alien points when collecting a bomb
- grant a fixed bonus based on the level
- freeze the ball during level transitions
- prevent bombs from spawning while transitioning

## Testing
- `node -e "require('fs').readFile('index.html','utf8',(e,d)=>{let s=d.match(/<script>([\s\S]*?)<\/script>/)[1]; try{new Function(s); console.log('OK')}catch(err){console.error(err)}})"`

------
https://chatgpt.com/codex/tasks/task_e_68611c6fa49c832c990962160ad75624