### PR TITLE
Reduce ball speed cap

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,8 @@
             transitioning: false
         };
 
-        const MAX_BALL_SPEED = 8;
+        // Lowered maximum ball speed for better playability
+        const MAX_BALL_SPEED = 6;
 
         function clampBallSpeed(ball) {
             const speed = Math.hypot(ball.velX, ball.velY);


### PR DESCRIPTION
## Summary
- lower the `MAX_BALL_SPEED` constant in the JS game code

## Testing
- `node` snippet to evaluate `clampBallSpeed` from the HTML source

------
https://chatgpt.com/codex/tasks/task_e_6861445a65e8832c99f07df4b039bb85