### PR TITLE
Fix bomb auto-activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,8 +407,10 @@
                     let dx = this.x - (bomb.x + bomb.width/2);
                     let dy = this.y - (bomb.y + bomb.height/2);
                     if (Math.sqrt(dx*dx + dy*dy) < this.radius + 15) {
-                        collectBomb(i);
-                        break;
+                        if (Date.now() - bomb.spawnTime >= 1000) {
+                            collectBomb(i);
+                            break;
+                        }
                     }
                 }
             }
@@ -499,6 +501,7 @@
                 this.height = 25;
                 this.velY = 1;
                 this.rotation = 0;
+                this.spawnTime = Date.now();
             }
             
             update() {


### PR DESCRIPTION
## Summary
- make bombs record spawnTime
- ignore ball collisions with bombs for the first second after spawn

## Testing
- `npx --yes serve -s .` *(fails: access denied)*

------
https://chatgpt.com/codex/tasks/task_e_686148330cd0832c9aafb1639ce85c8b