### PR TITLE
Award extra life every 5000 points

### DIFF
--- a/DesignDoc.md
+++ b/DesignDoc.md
@@ -114,9 +114,7 @@ To complete a level, the player must:
 
     Losing the ball reduces the life count by one.
 
-    If the player completes a level without losing any lives during that level, they are rewarded with an extra life.
-
-    The player can accumulate multiple extra lives but up to a reasonable maximum (e.g., 9).
+    Every 5000 points earned grants the player an extra life, up to a reasonable maximum (e.g., 9).
 
     The game ends if:
 

--- a/index.html
+++ b/index.html
@@ -235,6 +235,9 @@
             purpleSpawnChance: 0.001,
             killCounter: 0,
             maxKillCounter: 100,
+
+            // Extra life threshold
+            nextLifeScore: 5000,
             
 
             // High scores
@@ -417,6 +420,7 @@
                         
                         // Destroy alien
                         game.score += alien.points;
+                        checkExtraLife();
                         createParticles(alien.x + alien.width/2, alien.y + alien.height/2, alien.color);
                         if (alien.type === 3) {
                             game.bombs.push(new Bomb(alien.x, alien.y));
@@ -686,6 +690,7 @@
             game.score = 0;
             game.lives = 3;
             game.level = 1;
+            game.nextLifeScore = 5000;
             
             
             resetLevel();
@@ -873,6 +878,7 @@
             // Destroy all aliens and award fixed bonus points
             let bonusPoints = game.level * 100;
             game.score += bonusPoints;
+            checkExtraLife();
             
             // Create explosion particles
             game.aliens.forEach(alien => {
@@ -910,12 +916,6 @@
         }
         
         function nextLevel() {
-            // Bonus life if no lives lost this level
-            let livesAtStart = 3; // You'd track this properly in a full implementation
-            if (game.lives === livesAtStart) {
-                game.lives = Math.min(9, game.lives + 1);
-            }
-            
             game.level++;
             resetLevel();
         }
@@ -986,6 +986,15 @@
             document.getElementById('level').textContent = game.level;
             document.getElementById('lives').textContent = game.lives;
             document.getElementById('reinforcements').textContent = game.reinforcements;
+        }
+
+        function checkExtraLife() {
+            while (game.score >= game.nextLifeScore) {
+                if (game.lives < 9) {
+                    game.lives++;
+                }
+                game.nextLifeScore += 5000;
+            }
         }
         
         // High score system


### PR DESCRIPTION
## Summary
- remove old 'no death' bonus life at level change
- award extra life whenever score crosses 5000 point increments
- track threshold in game state and reset on new game
- document new scoring-based reward in design doc

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68616fa2cbc0832cb94f75945b91adcc