### PR TITLE
Fix restart bug after game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,6 +685,9 @@
                 game.inputLoopId = null;
             }
 
+            // Clear any pending restart flag so the new game loop runs
+            game.restartPending = false;
+
             game.running = true;
             game.paused = false;
             game.score = 0;
@@ -944,7 +947,8 @@
             document.getElementById('restartConfirm').style.display = 'none';
             document.getElementById('pauseOverlay').style.display = 'none';
             game.paused = false;
-            game.restartPending = true;
+            // If a game loop is active, flag it to stop on its next frame
+            game.restartPending = game.running;
             startGame();
         }
 


### PR DESCRIPTION
## Summary
- prevent `restartPending` from killing the new game loop when restarting from the Game Over screen
- reset the flag at the start of new games

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686170ea8a64832cbb3f155490b249fb