### PR TITLE
Store level in leaderboard

### DIFF
--- a/DesignDoc.md
+++ b/DesignDoc.md
@@ -132,7 +132,7 @@ To complete a level, the player must:
 
         Score.
 
-        Date of the score (if desired).
+        Maximum level reached.
 
     The high score list is saved between sessions and keeps the top 10 scores in descending order.
 

--- a/index.html
+++ b/index.html
@@ -1082,7 +1082,11 @@
             list.innerHTML = '';
             game.highScores.forEach(hs => {
                 const li = document.createElement('li');
-                li.textContent = `${hs.name} - ${hs.score}`;
+                if (hs.level !== undefined) {
+                    li.textContent = `${hs.name} - ${hs.score} (Lv ${hs.level})`;
+                } else {
+                    li.textContent = `${hs.name} - ${hs.score}`;
+                }
                 list.appendChild(li);
             });
         }
@@ -1097,7 +1101,7 @@
             game.highScores.push({
                 name: name,
                 score: game.score,
-                date: new Date().toLocaleDateString()
+                level: game.level
             });
 
             game.highScores.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary
- track level reached instead of date in leaderboard
- mention level reached in design doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68625e755d40832ca49d47bb2e64a813