### PR TITLE
Fix lingering bombs after level ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,7 @@
                         // Check for level completion
                         if (game.aliens.length === 0 && game.reinforcements === 0) {
                             freezeBall();
+                            game.bombs = [];
                             game.transitioning = true;
                             setTimeout(() => {
                                 nextLevel();
@@ -955,6 +956,7 @@
         function collectBomb(index) {
             // Remove bomb
             game.bombs.splice(index, 1);
+            game.bombs = [];
             playSound(game.sounds.bomb);
 
             // Freeze ball during level transition


### PR DESCRIPTION
## Summary
- clear bombs when the last alien dies
- clear bombs when any bomb ends the level

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_6862ada62194832c8641dd698644702b