### PR TITLE
Fix restart loop flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -880,8 +880,6 @@
                 game.inputLoopId = null;
             }
 
-            // Clear any pending restart flag so the new game loop runs
-            game.restartPending = false;
 
             game.running = true;
             game.paused = false;
@@ -1175,7 +1173,7 @@
             game.sounds.bgMusic.pause();
             // If a game loop is active, flag it to stop on its next frame
             game.restartPending = game.running;
-            startGame();
+            requestAnimationFrame(startGame);
         }
 
         function pauseGame() {


### PR DESCRIPTION
## Summary
- avoid clearing restart flag inside `startGame`
- schedule `startGame` on the next frame when restarting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867b92a4ce4832cbef2e4981f9617ef