### PR TITLE
Fix stuck level when last alien killed by bullet

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,14 +493,7 @@
                         this.velY = -this.velY;
                         
                         // Check for level completion
-                        if (game.aliens.length === 0 && game.reinforcements === 0) {
-                            freezeBall();
-                            game.bombs = [];
-                            game.transitioning = true;
-                            setTimeout(() => {
-                                nextLevel();
-                            }, 1000);
-                        }
+                        checkLevelCompletion();
                         
                         break;
                     }
@@ -591,6 +584,7 @@
                         }
                         game.aliens.splice(i,1);
                         playSound(game.sounds.alien);
+                        checkLevelCompletion();
                         this.destroy();
                         return;
                     }
@@ -1234,6 +1228,17 @@
                     game.lives++;
                 }
                 game.nextLifeScore += 5000;
+            }
+        }
+
+        function checkLevelCompletion() {
+            if (game.aliens.length === 0 && game.reinforcements === 0 && !game.transitioning) {
+                freezeBall();
+                game.bombs = [];
+                game.transitioning = true;
+                setTimeout(() => {
+                    nextLevel();
+                }, 1000);
             }
         }
         


### PR DESCRIPTION
## Summary
- centralize level completion logic in `checkLevelCompletion`
- call this check from both ball and bullet alien collisions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867bc868e58832c932563bb88abb26e